### PR TITLE
chore: upgrade cobra dependencies

### DIFF
--- a/geckopy/model.py
+++ b/geckopy/model.py
@@ -127,7 +127,7 @@ class Model(cobra.Model):
         fn_mass_fraction_unmeasured_matched: float,
         protein_list: List[str] = None,
     ):
-        """Constrain the draw reactions for the unmeasured (common protein pool) proteins.
+        """Constrain the draw reactions for unmeasured (common protein pool) proteins.
 
         Adapted from [geckopy]
         (https://github.com/SysBioChalmers/GECKO/blob/master/geckopy/geckopy/gecko.py#L184)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ version = 0.0.1
 [options]
 zip_safe = True
 install_requires =
-    cobra~=0.20.0
+    cobra~=0.25.0
     pandas~=1.1.5
     tqdm~=4.60
 packages = find:


### PR DESCRIPTION
Upgrade cobra dependency so that libsbml does not break in windows python3.9 like in #5 