### PR TITLE
refactor: match identifers as they appear in data when limiting proteins

### DIFF
--- a/docs/02-experimental.rst
+++ b/docs/02-experimental.rst
@@ -30,7 +30,8 @@ Experimental data
     
     ec_model_exp = geckopy.experimental.from_copy_number(
         ec_model,
-        index=raw_proteomics["uniprot"],
+        # the index should be the IDs of the proteins exactly as in the model!
+        index=raw_proteomics["uniprot"].apply(lambda x: f"prot_{x}"),
         cell_copies = raw_proteomics["copies_per_cell"], 
         stdev = raw_proteomics["stdev"],
         vol=2.3, dens=1.105e-12, water=0.3

--- a/docs/03-thermodynamics.rst
+++ b/docs/03-thermodynamics.rst
@@ -260,7 +260,8 @@ or the thermodynamic constraint, see the
     raw_proteomics = pd.read_csv(DATA / "ecoli_proteomics_schmidt2016S5.tsv")
     ec_model_constrained = from_copy_number(
         ec_model.copy(),
-        index=raw_proteomics["uniprot"],
+        # the index should be the IDs of the proteins exactly as in the model!
+        index=raw_proteomics["uniprot"].apply(lambda x: f"prot_{x}"),
         cell_copies=raw_proteomics["copies_per_cell"],
         stdev=raw_proteomics["stdev"],
         vol=2.3,
@@ -308,7 +309,8 @@ will simply remove their concentrations for illustration purposes.
 
     ec_model_constrained = from_copy_number(
         ec_model.copy(),
-        index=raw_proteomics["uniprot"],
+        # the index should be the IDs of the proteins exactly as in the model!
+        index=raw_proteomics["uniprot"].apply(lambda x: f"prot_{x}"),
         cell_copies=raw_proteomics["copies_per_cell"],
         stdev=raw_proteomics["stdev"],
         vol=2.3,

--- a/tests/test_integration/test_relaxation.py
+++ b/tests/test_integration/test_relaxation.py
@@ -41,7 +41,8 @@ def test_relax_thermo_dgr_and_proteins_works(
     raw_proteomics = pd.read_csv(experimental_copy_number)
     ec_model = from_copy_number(
         ec_model_core.copy(),
-        index=raw_proteomics["uniprot"],
+        # proteins in the model are in prot_UNIPROT form
+        index=raw_proteomics["uniprot"].apply(lambda x: f"prot_{x}"),
         cell_copies=raw_proteomics["copies_per_cell"],
         stdev=raw_proteomics["stdev"],
         vol=2.3,
@@ -66,7 +67,8 @@ def test_relax_thermo_dgr_and_proteins_works(
     assert status == "optimal"
     ec_model = from_copy_number(
         ec_model_core.copy(),
-        index=raw_proteomics["uniprot"],
+        # proteins in the model are in prot_UNIPROT form
+        index=raw_proteomics["uniprot"].apply(lambda x: f"prot_{x}"),
         cell_copies=raw_proteomics["copies_per_cell"],
         stdev=raw_proteomics["stdev"],
         vol=2.3,
@@ -93,7 +95,8 @@ def test_relax_concentrations_and_proteins_works(
     raw_proteomics = pd.read_csv(experimental_copy_number)
     ec_model = from_copy_number(
         ec_model_core.copy(),
-        index=raw_proteomics["uniprot"],
+        # proteins in the model are in prot_UNIPROT form
+        index=raw_proteomics["uniprot"].apply(lambda x: f"prot_{x}"),
         cell_copies=raw_proteomics["copies_per_cell"],
         stdev=raw_proteomics["stdev"],
         vol=2.3,


### PR DESCRIPTION
Related to #7 

### Description

Previously, the [`limit_proteins`](https://geckopy.readthedocs.io/en/latest/autoapi/geckopy/experimental/index.html?highlight=limit_proteins#geckopy.experimental.limit_proteins) function (endpoint to all of the proteomics integration) was expecting the identifiers in the model to be `prot_ID`, where "ID" is the identifier provided in the measurements data. This was very lacking because models like ecYeast do not use `prot_` prefixes.

### Implementation
Match protein identifiers as they appear in the data, without any modifications.

* Tests and docs were updated.
* `limit_proteins` correctly hints for a `pd.Series` instead of a `pd.DataFrame`.