### PR TITLE
feat: support Mw/kcat models from GECKO 3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         exclude:
         # Lacking swiglpk wheels for this combination.
         - os: macos-latest

--- a/geckopy/experimental/relaxation.py
+++ b/geckopy/experimental/relaxation.py
@@ -360,6 +360,6 @@ def relax_proteomics_greedy(
             f"Final growth of the model: {new_growth_rate}"
         )
         LOGGER.warn(message)
-        warnings.warn(message)
+        warnings.warn(message, stacklevel=2)
 
     return new_growth_rate, prots_to_remove

--- a/geckopy/flux_analysis.py
+++ b/geckopy/flux_analysis.py
@@ -229,7 +229,7 @@ def flux_variability_analysis(
             raise UserInputModelClash(f"{reac} to be fixed is not in model {model.id}.")
         reac_to_fix, lb = fix_reaction_to_min(model, model.reactions.get_by_id(reac))
         model.reactions.get_by_id(reac_to_fix).bounds = lb, lb
-        fva_result.at[reac, :] = (-lb, -lb) if reac != reac_to_fix else (lb, lb)
+        fva_result.loc[reac, :] = [-lb, -lb] if reac != reac_to_fix else [lb, lb]
     LOGGER.debug(
         f"FVA started for a model with {len(model.reactions)} and"
         f"{len(reac_ids)} effective reactions"
@@ -247,7 +247,7 @@ def flux_variability_analysis(
                 total=len(reac_ids),
                 desc="FVA",
             ):
-                fva_result.at[rxn_id, :] = lb, ub
+                fva_result.loc[rxn_id, :] = [lb, ub]
     else:
         _init_worker(model)
         for rxn_id, lb, ub in tqdm(
@@ -255,7 +255,7 @@ def flux_variability_analysis(
             total=len(reac_ids),
             desc="FVA",
         ):
-            fva_result.at[rxn_id, :] = lb, ub
+            fva_result.loc[rxn_id, :] = [lb, ub]
 
     return fva_result
 
@@ -327,7 +327,7 @@ def protein_variability_analysis(
                 total=len(proteins),
                 desc="FVA",
             ):
-                fva_result.at[rxn_id, :] = lb, ub
+                fva_result.loc[rxn_id, :] = lb, ub
     else:
         _init_worker(model, "proteins")
         for rxn_id, lb, ub in tqdm(
@@ -335,7 +335,7 @@ def protein_variability_analysis(
             total=len(proteins),
             desc="FVA",
         ):
-            fva_result.at[rxn_id, :] = lb, ub
+            fva_result.loc[rxn_id, :] = lb, ub
     return fva_result
 
 

--- a/geckopy/flux_analysis.py
+++ b/geckopy/flux_analysis.py
@@ -19,7 +19,7 @@ import re
 from itertools import chain
 from math import isnan
 from multiprocessing import Pool
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import cobra
 import pandas as pd
@@ -154,8 +154,8 @@ def fix_reaction_to_min(model: cobra.Model, reac: cobra.Reaction) -> Tuple[str, 
 
 def flux_variability_analysis(
     ec_model: Model,
-    fixed_reactions: Optional[List[str]] = None,
-    ignored_reactions: Optional[List[str]] = None,
+    fixed_reactions: Optional[Union[List[str], str]] = None,
+    ignored_reactions: Optional[Union[List[str], str]] = None,
     n_proc: Optional[int] = config.processes,
     inplace: bool = False,
 ) -> pd.DataFrame:

--- a/geckopy/io/__init__.py
+++ b/geckopy/io/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .sbml import read_sbml_ec_model, write_sbml_ec_model
+from .sbml import EcStoichiometry, read_sbml_ec_model, write_sbml_ec_model
 from .standard import group_proteins

--- a/geckopy/io/__init__.py
+++ b/geckopy/io/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .sbml import EcStoichiometry, read_sbml_ec_model, write_sbml_ec_model
-from .standard import group_proteins
+from .sbml import read_sbml_ec_model, write_sbml_ec_model
+from .standard import EcStoichiometry, group_proteins

--- a/geckopy/io/sbml.py
+++ b/geckopy/io/sbml.py
@@ -686,7 +686,6 @@ def read_sbml_ec_model(
             model.getListOfReactions(),
             model_groups.getListOfGroups(),
         ]:
-
             for sbase in obj_list:  # type: libsbml.SBase
                 if sbase.isSetId():
                     sid_map[sbase.getIdAttribute()] = sbase
@@ -1120,7 +1119,6 @@ def write_sbml_ec_model(
         # GPR
         gpr = cobra_reaction.gene_reaction_rule
         if gpr is not None and len(gpr) > 0:
-
             # replace ids in string
             if f_replace and F_GENE_REV in f_replace:
                 gpr = gpr.replace("(", "( ")

--- a/geckopy/io/sbml.py
+++ b/geckopy/io/sbml.py
@@ -843,9 +843,9 @@ def write_sbml_ec_model(
         and which are not part of the :code:`Protein` group will be added to it.
         This is an inplace operation!
     ec_stoichiometry: EcStoichiometry, default=EcStoichiometry.KCAT
-        if KCAT, enzyme stoichiometric coefficients will be written as $\frac{1}{k_{cat}}$.
-        Else, enzyme stoichiometric coefficients will be written as $\frac{M_w}{k_{cat}}$ (compatible
-        with GECKO 3).
+        if KCAT, enzyme stoichiometric coefficients will be written as
+        $\frac{1}{k_{cat}}$. Else, enzyme stoichiometric coefficients will
+        be written as $\frac{M_w}{k_{cat}}$ (compatible with GECKO 3).
 
     Raises
     ------
@@ -857,7 +857,9 @@ def write_sbml_ec_model(
     protein_pool_metabolite = None
     protein_pool_exchange = None
     if hasattr(ec_model, "protein_pool_exchange"):
-        warnings.warn("Protein pool will not be serialized to the SBML document.")
+        warnings.warn(
+            "Protein pool will not be serialized to the SBML document.", stacklevel=2
+        )
         protein_pool_metabolite = ec_model.common_protein_pool
         protein_pool_exchange = ec_model.protein_pool_exchange
     if f_replace is None:

--- a/geckopy/io/standard.py
+++ b/geckopy/io/standard.py
@@ -16,11 +16,19 @@
 
 import warnings
 from collections import Counter
+from enum import Enum
 from typing import List, Optional, Union
 
 from cobra.core.group import Group
 
 from geckopy.model import Model, Protein
+
+
+class EcStoichiometry(Enum):
+    """Fashion of stoichiometric coeffients for enzymes (GECKO < or >= 3.0)."""
+
+    KCAT = "KCAT"
+    MW_KCAT = "MW_KCAT"
 
 
 def group_proteins(

--- a/geckopy/io/standard.py
+++ b/geckopy/io/standard.py
@@ -65,7 +65,10 @@ def annotate_gene_protein_rules(model: Model):
     more thought should be put in how to make the GPR into something typed in the
     SBML doc that relates to the actual data structures in the model.
     """
-    warnings.warn("This function is experimental and subject to change in the future.")
+    warnings.warn(
+        "This function is experimental and subject to change in the future.",
+        stacklevel=2,
+    )
     # add empty attributes for the proteins for consistency
     for prot in model.proteins:
         prot.gene = None

--- a/geckopy/model.py
+++ b/geckopy/model.py
@@ -453,7 +453,6 @@ class Model(cobra.Model):
         # Make sure proteins exist in model
         protein_list = [x for x in protein_list if x.id in self.proteins]
         for x in protein_list:
-
             # remove reference to the protein in all groups
             associated_groups = self.get_associated_groups(x)
             for group in associated_groups:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ install_requires =
     pandas~=1.1.5
     tqdm~=4.60
     requests>=2
+	# to avoid numpy raising an error from cobrapy
+	numpy~=1.23.1
 packages = find:
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ install_requires =
     tqdm~=4.60
     requests>=2
 	# to avoid numpy raising an error from cobrapy
-	numpy~=1.23.1
+	numpy<=1.23.1
 packages = find:
 
 [options.extras_require]

--- a/tests/test_unit/test_flux_analysis.py
+++ b/tests/test_unit/test_flux_analysis.py
@@ -71,7 +71,7 @@ def test_expected_bottleneck(ec_model_core):
         prot.mw = 33000
     ec_model_core.constrain_pool(0.00448, 0.65, 1)
     bottlenecks = get_protein_bottlenecks(ec_model_core, 10)
-    assert (bottlenecks.protein == "prot_P27306").any()
+    assert (bottlenecks.protein == "prot_P61889").any()
 
 
 def test_kcat_concentration_rate(ec_model_core):
@@ -90,7 +90,7 @@ def test_coverage_of_enzyme_saturation_on_fully_saturated_model(ec_model_core):
     solution["protein"] = solution.index
     solution.apply(
         lambda x: ec_model_core.proteins.get_by_id(x.protein).add_concentration(
-            x.fluxes
+            x.fluxes if x.fluxes > 1e-8 else 0
         ),
         axis=1,
     )


### PR DESCRIPTION
### Description

As risen by @edkerk, the matlab toolbox GECKO 3.0 has changed the specification of stoichiometric coefficients  for enzymes (see [here](https://github.com/SysBioChalmers/GECKO#previous-versions-gecko-1-and-2)). The coefficients which were previously $\frac1 {k_{cat}}$ has been changed to be $\frac {M_w} {k_{cat}}$.

Geckopy should remain compatible with GECKO, so it should support this coefficient fashion.

### Implementation

This PR achieves (shallow) interoperability at the document level; i. e., the writing and reading function of SBML now accept a flag to read SBML models with the GECKO3 encoding. The default remains the same (i.e., _legacy_ encoding) and the inner workings of geckopy are still in $\frac1 {k_{cat}}$.

Reading and writing with the  $\frac {M_w} {k_{cat}}$ will raise an error if no $M_w$ is found in a protein. For reading, this relies on the annotation attribute, using "mw" as the field (to follow the name used in GECKO3 YAML, see [this example](https://github.com/SysBioChalmers/GECKO/blob/main/userData/ecYeastGEM/models/ecYeastGEMfull.yml)). A test was implemented for reading and writing with this format.

I had to remove support for python 3.6 since Github Actions does not support it for `ubuntu-latest` (and it is deprecated anyways). python3.10 was not added to CI but it should in the future (see #11).