### PR TITLE
fix: add back MW fallback

### DIFF
--- a/geckopy/experimental/molecular_weights.py
+++ b/geckopy/experimental/molecular_weights.py
@@ -17,6 +17,7 @@
 import gzip
 import io
 import re
+from collections import defaultdict
 from time import sleep
 from typing import Callable, Dict, List, Optional
 
@@ -87,6 +88,9 @@ def _molecular_weight(seq: str) -> float:
     """
     seq = "".join(str(seq).split()).upper()  # Do the minimum formatting
     weight_table = protein_weights
+    weight_table = defaultdict(
+        lambda: sum(weight_table.values()) / len(weight_table), weight_table
+    )
     water = 18.010565
 
     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ version = 0.0.1
 [options]
 zip_safe = True
 install_requires =
-    cobra~=0.25.0
+    cobra~=0.27.0
     pandas~=1.1.5
     tqdm~=4.60
     requests>=2


### PR DESCRIPTION
Closes https://github.com/carrascomj/simult_supp_material/issues/1

It seems like the molecular weight fallback for unknown aminoacids was removed at some point, I don't really remember why, probably unintendedly.